### PR TITLE
Proper check for `usePvPParticle` in OnClientModelChanged

### DIFF
--- a/scripting/pvpoptin/dtours.sp
+++ b/scripting/pvpoptin/dtours.sp
@@ -291,7 +291,7 @@ void OnClientModelChanged(int userid) {
 	if (!IsPlayerModelValid(client)) {
 		SetGlobalPvP(client, false);
 	} else {
-		clientForceUpdateParticle[client] = true;
+		if (usePvPParticle) clientForceUpdateParticle[client] = true;
 		UpdateEntityFlagsGlobalPvP(client, IsGlobalPvP(client));
 	}
 }

--- a/scripting/pvpoptin/utils.sp
+++ b/scripting/pvpoptin/utils.sp
@@ -77,7 +77,7 @@ void UpdatePvPParticles(int client) {
 	if (TF2_IsPlayerInCondition(client, TFCond_Disguised)) effectiveClass = view_as<TFClassType>(GetEntProp(client, Prop_Send, "m_nDisguiseClass"));
 	if (effectiveClass == TFClass_Unknown) effectiveClass = TF2_GetPlayerClass(client);
 	
-	if (tmask != clientParticleAttached[client] || clientForceUpdateParticle[client]) {
+	if (tmask != clientParticleAttached[client] && clientForceUpdateParticle[client]) {
 		clientForceUpdateParticle[client] = false;
 		// if particles tunred off for some clients, we have to restart them
 		// we will also simply restart them for everyone if some new gets to see it


### PR DESCRIPTION
~~Fix #12 . My server is constantly changing player's model with other plugin.~~
~~Not fixed.~~
Fixed.